### PR TITLE
Fix build in centos 7 with gcc 7.2, 7.3, 8.2

### DIFF
--- a/zlib.h
+++ b/zlib.h
@@ -31,6 +31,7 @@
 */
 
 #include <stdint.h>
+#include <stdarg.h>
 #include "zconf.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
To be honest I suspect there might be a toolchain breakage in centos env, but this fixes all the hassles.