### PR TITLE
Fix static_ltree extern declaration in deflate_quick.c

### DIFF
--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -165,7 +165,7 @@ static inline void static_emit_ptr(deflate_state *const s, const int lc, const u
     quick_send_bits(s, code1, len1, code2, len2);
 }
 
-const ct_data static_ltree[L_CODES+2];
+extern const ct_data static_ltree[L_CODES+2];
 
 static inline void static_emit_lit(deflate_state *const s, const int lit) {
     quick_send_bits(s, static_ltree[lit].Code, static_ltree[lit].Len, 0, 0);


### PR DESCRIPTION
**NOTE: destination branch is `develop-old`** (the one that is used in https://github.com/ClickHouse/ClickHouse/blob/0b071211771c4edc5c5c8e728c7d8d90e8651e2e/.gitmodules#L19)

Until [zlib-ng will be fixed](https://github.com/ClickHouse/ClickHouse/pull/10966#issuecomment-680035427), quick fix for gcc10