### PR TITLE
Workaround for arm64 AppleClang linker issue

### DIFF
--- a/arch/arm/arm.h
+++ b/arch/arm/arm.h
@@ -5,6 +5,13 @@
 #ifndef ARM_H_
 #define ARM_H_
 
+/*
+ A hack that helps AppleClang linker to see arm_cpu_has_* flags.
+ A single call to dummy_linker_glue() in the compilation unit that reads
+ arm_cpu_has_* flags will resolve "undefined symbol" link error.
+*/
+void dummy_linker_glue();
+
 extern int arm_cpu_has_neon;
 extern int arm_cpu_has_crc32;
 

--- a/arch/arm/armfeature.c
+++ b/arch/arm/armfeature.c
@@ -7,6 +7,8 @@
 # include <winapifamily.h>
 #endif
 
+ZLIB_INTERNAL void dummy_linker_glue(void) {}
+
 static int arm_has_crc32() {
 #if defined(__linux__) && defined(HWCAP2_CRC32)
   return (getauxval(AT_HWCAP2) & HWCAP2_CRC32) != 0 ? 1 : 0;

--- a/functable.c
+++ b/functable.c
@@ -121,6 +121,7 @@ ZLIB_INTERNAL uint32_t adler32_stub(uint32_t adler, const unsigned char *buf, si
     functable.adler32=&adler32_c;
 
     #if (defined(__ARM_NEON__) || defined(__ARM_NEON)) && defined(ARM_NEON_ADLER32)
+    dummy_linker_glue();
     if (arm_cpu_has_neon)
         functable.adler32=&adler32_neon;
     #endif


### PR DESCRIPTION
Use dummy_linker_glue() function to workaround arm64 AppleClang linker issue.