### PR TITLE
Backport Check for x86 features when the library is loaded.

### DIFF
--- a/arch/arm/arm.h
+++ b/arch/arm/arm.h
@@ -15,6 +15,4 @@ void dummy_linker_glue();
 extern int arm_cpu_has_neon;
 extern int arm_cpu_has_crc32;
 
-void Z_INTERNAL arm_check_features(void);
-
 #endif /* ARM_H_ */

--- a/arch/arm/armfeature.c
+++ b/arch/arm/armfeature.c
@@ -61,7 +61,7 @@ static inline int arm_has_neon() {
 Z_INTERNAL int arm_cpu_has_neon;
 Z_INTERNAL int arm_cpu_has_crc32;
 
-void Z_INTERNAL arm_check_features(void) {
+static void __attribute__((constructor)) arm_check_features(void) {
 #if defined(__aarch64__) || defined(_M_ARM64)
     arm_cpu_has_neon = 1; /* always available */
 #else

--- a/arch/x86/x86.c
+++ b/arch/x86/x86.c
@@ -52,9 +52,9 @@ static void cpuidex(int info, int subinfo, unsigned* eax, unsigned* ebx, unsigne
 #endif
 }
 
-void Z_INTERNAL x86_check_features(void) {
-    unsigned eax, ebx, ecx, edx;
-    unsigned maxbasic;
+static void __attribute__((constructor)) x86_check_features(void) {
+	unsigned eax, ebx, ecx, edx;
+	unsigned maxbasic;
 
     cpuid(0, &maxbasic, &ebx, &ecx, &edx);
 

--- a/arch/x86/x86.h
+++ b/arch/x86/x86.h
@@ -13,6 +13,4 @@ extern int x86_cpu_has_sse42;
 extern int x86_cpu_has_pclmulqdq;
 extern int x86_cpu_has_tzcnt;
 
-void Z_INTERNAL x86_check_features(void);
-
 #endif /* CPU_H_ */

--- a/deflate.c
+++ b/deflate.c
@@ -259,12 +259,6 @@ int32_t Z_EXPORT PREFIX(deflateInit2_)(PREFIX3(stream) *strm, int32_t level, int
     int wrap = 1;
     static const char my_version[] = PREFIX2(VERSION);
 
-#if defined(X86_FEATURES)
-    x86_check_features();
-#elif defined(ARM_FEATURES)
-    arm_check_features();
-#endif
-
     if (version == NULL || version[0] != my_version[0] || stream_size != sizeof(PREFIX3(stream))) {
         return Z_VERSION_ERROR;
     }

--- a/inflate.c
+++ b/inflate.c
@@ -132,12 +132,6 @@ int32_t Z_EXPORT PREFIX(inflateInit2_)(PREFIX3(stream) *strm, int32_t windowBits
     int32_t ret;
     struct inflate_state *state;
 
-#if defined(X86_FEATURES)
-    x86_check_features();
-#elif defined(ARM_FEATURES)
-    arm_check_features();
-#endif
-
     if (version == NULL || version[0] != PREFIX2(VERSION)[0] || stream_size != (int)(sizeof(PREFIX3(stream))))
         return Z_VERSION_ERROR;
     if (strm == NULL)


### PR DESCRIPTION
Checking in initDeflate() call is problematic, because it can be called
from different threads concurrently. This doesn't lead to any problems
in practice, but technically this is undefined behavior, and also leads
to ThreadSanitizer warnings.