### PR TITLE
Fix the Apple linker error

### DIFF
--- a/arch/arm/armfeature.c
+++ b/arch/arm/armfeature.c
@@ -66,8 +66,8 @@ static inline int arm_has_neon() {
 }
 #endif
 
-Z_INTERNAL int arm_cpu_has_neon;
-Z_INTERNAL int arm_cpu_has_crc32;
+Z_INTERNAL int arm_cpu_has_neon = 0;
+Z_INTERNAL int arm_cpu_has_crc32 = 0;
 
 void __attribute__((constructor)) arm_check_features(void) {
 #if defined(__aarch64__) || defined(_M_ARM64)

--- a/arch/x86/x86.h
+++ b/arch/x86/x86.h
@@ -12,6 +12,5 @@ extern int x86_cpu_has_ssse3;
 extern int x86_cpu_has_sse42;
 extern int x86_cpu_has_pclmulqdq;
 extern int x86_cpu_has_tzcnt;
-extern int x86_cpu_has_avx2;
 
 #endif /* CPU_H_ */

--- a/zlib.h
+++ b/zlib.h
@@ -1766,6 +1766,7 @@ Z_EXTERN int Z_EXPORT inflateBackInit_(z_stream *strm, int windowBits, unsigned 
                         inflateBackInit_((strm), (windowBits), (window), ZLIB_VERSION, (int)sizeof(z_stream))
 
 
+#ifndef Z_SOLO
 /* gzgetc() macro and its supporting function and exposed data structure.  Note
  * that the real internal state is much larger than the exposed structure.
  * This abbreviated structure exposes just enough for the gzgetc() macro.  The
@@ -1795,6 +1796,7 @@ Z_EXTERN int Z_EXPORT gzgetc_(gzFile file);  /* backward compatibility */
    Z_EXTERN unsigned long Z_EXPORT adler32_combine64(unsigned long, unsigned long, z_off64_t);
    Z_EXTERN unsigned long Z_EXPORT crc32_combine64(unsigned long, unsigned long, z_off64_t);
    Z_EXTERN void Z_EXPORT crc32_combine_gen64(uint32_t *op, z_off64_t);
+#endif
 #endif
 
 #if !defined(Z_INTERNAL) && defined(Z_WANT64)
@@ -1834,10 +1836,12 @@ Z_EXTERN unsigned long    Z_EXPORT inflateCodesUsed (z_stream *);
 Z_EXTERN int              Z_EXPORT inflateResetKeep (z_stream *);
 Z_EXTERN int              Z_EXPORT deflateResetKeep (z_stream *);
 
+#ifndef Z_SOLO
 #if defined(_WIN32)
     Z_EXTERN gzFile Z_EXPORT gzopen_w(const wchar_t *path, const char *mode);
 #endif
 Z_EXTERN int Z_EXPORTVA gzvprintf(gzFile file, const char *format, va_list va);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fix the Apple linker error introduced by ClickHouse-specific changes.
Merge upstream's `stable` branch in.