### PR TITLE
Zlib patch: prevent uninitialized use of state->check

### DIFF
--- a/inflate.c
+++ b/inflate.c
@@ -1198,6 +1198,8 @@ int32_t Z_EXPORT PREFIX(inflateSync)(PREFIX3(stream) *strm) {
     /* return no joy or set up to restart inflate() on a new block */
     if (state->have != 4)
         return Z_DATA_ERROR;
+    if (state->mode == HEAD)
+        state->wrap = 0;
     if (state->flags == -1)
         state->wrap = 0;    /* if no header yet, treat as raw */
     else


### PR DESCRIPTION
This CL fixes a security bug in zlib. It was reported upstream long ago
and the testcase was shared upstream but it's yet unsolved. As a fix,
state->check is set to the same value as the adler32 of an empty string.

Upstream bug: https://github.com/madler/zlib/issues/245

[WS-2020-0368](https://github.com/madler/zlib/commit/44e8ac810d7d50381429a15cdc6e48816beafd2b)