### PR TITLE
Use constructors for functable again

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -194,9 +194,6 @@ int32_t ZNG_CONDEXPORT PREFIX(deflateInit2)(PREFIX3(stream) *strm, int32_t level
     deflate_state *s;
     int wrap = 1;
 
-    /* Force initialization functable, because deflate captures function pointers from functable. */
-    functable.force_init();
-
     if (strm == NULL)
         return Z_STREAM_ERROR;
 

--- a/functable.c
+++ b/functable.c
@@ -39,18 +39,13 @@
 #  define FUNCTABLE_BARRIER() do { /* Empty */ } while (0)
 #endif
 
-static void force_init_empty(void) {
-    // empty
-}
-
-static void init_functable(void) {
+static void __attribute__((constructor)) init_functable(void) {
     struct functable_s ft;
     struct cpu_features cf;
 
     cpu_check_features(&cf);
 
     // Generic code
-    ft.force_init = &force_init_empty;
     ft.adler32 = &adler32_c;
     ft.adler32_fold_copy = &adler32_fold_copy_c;
     ft.chunkmemset_safe = &chunkmemset_safe_c;
@@ -267,7 +262,6 @@ static void init_functable(void) {
 #endif
 
     // Assign function pointers individually for atomic operation
-    FUNCTABLE_ASSIGN(ft, force_init);
     FUNCTABLE_ASSIGN(ft, adler32);
     FUNCTABLE_ASSIGN(ft, adler32_fold_copy);
     FUNCTABLE_ASSIGN(ft, chunkmemset_safe);
@@ -290,116 +284,6 @@ static void init_functable(void) {
     FUNCTABLE_BARRIER();
 }
 
-/* stub functions */
-static void force_init_stub(void) {
-    init_functable();
-}
-
-static uint32_t adler32_stub(uint32_t adler, const uint8_t* buf, size_t len) {
-    init_functable();
-    return functable.adler32(adler, buf, len);
-}
-
-static uint32_t adler32_fold_copy_stub(uint32_t adler, uint8_t* dst, const uint8_t* src, size_t len) {
-    init_functable();
-    return functable.adler32_fold_copy(adler, dst, src, len);
-}
-
-static uint8_t* chunkmemset_safe_stub(uint8_t* out, unsigned dist, unsigned len, unsigned left) {
-    init_functable();
-    return functable.chunkmemset_safe(out, dist, len, left);
-}
-
-static uint32_t chunksize_stub(void) {
-    init_functable();
-    return functable.chunksize();
-}
-
-static uint32_t compare256_stub(const uint8_t* src0, const uint8_t* src1) {
-    init_functable();
-    return functable.compare256(src0, src1);
-}
-
-static uint32_t crc32_stub(uint32_t crc, const uint8_t* buf, size_t len) {
-    init_functable();
-    return functable.crc32(crc, buf, len);
-}
-
-static void crc32_fold_stub(crc32_fold* crc, const uint8_t* src, size_t len, uint32_t init_crc) {
-    init_functable();
-    functable.crc32_fold(crc, src, len, init_crc);
-}
-
-static void crc32_fold_copy_stub(crc32_fold* crc, uint8_t* dst, const uint8_t* src, size_t len) {
-    init_functable();
-    functable.crc32_fold_copy(crc, dst, src, len);
-}
-
-static uint32_t crc32_fold_final_stub(crc32_fold* crc) {
-    init_functable();
-    return functable.crc32_fold_final(crc);
-}
-
-static uint32_t crc32_fold_reset_stub(crc32_fold* crc) {
-    init_functable();
-    return functable.crc32_fold_reset(crc);
-}
-
-static void inflate_fast_stub(PREFIX3(stream) *strm, uint32_t start) {
-    init_functable();
-    functable.inflate_fast(strm, start);
-}
-
-static void insert_string_stub(deflate_state* const s, uint32_t str, uint32_t count) {
-    init_functable();
-    functable.insert_string(s, str, count);
-}
-
-static uint32_t longest_match_stub(deflate_state* const s, Pos cur_match) {
-    init_functable();
-    return functable.longest_match(s, cur_match);
-}
-
-static uint32_t longest_match_slow_stub(deflate_state* const s, Pos cur_match) {
-    init_functable();
-    return functable.longest_match_slow(s, cur_match);
-}
-
-static Pos quick_insert_string_stub(deflate_state* const s, const uint32_t str) {
-    init_functable();
-    return functable.quick_insert_string(s, str);
-}
-
-static void slide_hash_stub(deflate_state* s) {
-    init_functable();
-    functable.slide_hash(s);
-}
-
-static uint32_t update_hash_stub(deflate_state* const s, uint32_t h, uint32_t val) {
-    init_functable();
-    return functable.update_hash(s, h, val);
-}
-
-/* functable init */
-Z_INTERNAL struct functable_s functable = {
-    force_init_stub,
-    adler32_stub,
-    adler32_fold_copy_stub,
-    chunkmemset_safe_stub,
-    chunksize_stub,
-    compare256_stub,
-    crc32_stub,
-    crc32_fold_stub,
-    crc32_fold_copy_stub,
-    crc32_fold_final_stub,
-    crc32_fold_reset_stub,
-    inflate_fast_stub,
-    insert_string_stub,
-    longest_match_stub,
-    longest_match_slow_stub,
-    quick_insert_string_stub,
-    slide_hash_stub,
-    update_hash_stub
-};
+Z_INTERNAL struct functable_s functable;
 
 Z_INTERNAL void dummy_linker_glue(void) {}

--- a/functable.h
+++ b/functable.h
@@ -24,7 +24,6 @@ typedef struct zng_stream_s zng_stream;
 void dummy_linker_glue();
 
 struct functable_s {
-    void     (* force_init)         (void);
     uint32_t (* adler32)            (uint32_t adler, const uint8_t *buf, size_t len);
     uint32_t (* adler32_fold_copy)  (uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
     uint8_t* (* chunkmemset_safe)   (uint8_t *out, unsigned dist, unsigned len, unsigned left);

--- a/inflate.c
+++ b/inflate.c
@@ -139,9 +139,6 @@ int32_t ZNG_CONDEXPORT PREFIX(inflateInit2)(PREFIX3(stream) *strm, int32_t windo
     int32_t ret;
     struct inflate_state *state;
 
-    /* Initialize functable earlier. */
-    functable.force_init();
-
     if (strm == NULL)
         return Z_STREAM_ERROR;
     strm->msg = NULL;                   /* in case we return an error */


### PR DESCRIPTION
Re-do https://github.com/ClickHouse/zlib-ng/pull/7 , but it's simpler this time because upstream centralized all initialization into one function call.

(In https://github.com/ClickHouse/zlib-ng/pull/17 I incorrectly thought this isn't needed because `init_functable()` was changed upstream to do atomic writes to assign function pointers. But reads are still non-atomic, so TSAN complains.)